### PR TITLE
Update IDA API function names

### DIFF
--- a/strcluster.py
+++ b/strcluster.py
@@ -13,6 +13,7 @@ import idautils
 import idc
 import idaapi
 from idaapi import PluginForm
+from ida_kernwin import jumpto
 
 import time
 
@@ -123,8 +124,8 @@ class StringClusterMap(PluginForm):
 			for fs_ea in s_xrefs_eas:
 				dprint("looking for function of %x" %(fs_ea))
 
-				f_name = idc.GetFunctionName(fs_ea)
-				f_ea = idc.GetFunctionAttr(fs_ea, idc.FUNCATTR_START)
+				f_name = idc.get_func_name(fs_ea)
+				f_ea = idc.get_func_attr(fs_ea, idc.FUNCATTR_START)
 				if not f_name or f_name == '': f_name = NO_FUNC
 				if f_ea in res:
 					res[f_ea]['strings'][s_v] = IdaString(s_v, s_ea, fs_ea)
@@ -216,7 +217,7 @@ class StringClusterMap(PluginForm):
 			return
 
 		if ea != -1:
-			idc.Jump(ea)
+			jumpto(ea)
 
 	def PopulateForm(self):
 		self.parent.setWindowIcon(self.getIcon())


### PR DESCRIPTION
I found some function names used in `strcluster.py` to be outdated. I referred to this page for updated function names: https://www.hex-rays.com/products/ida/support/ida74_idapython_no_bc695_porting_guide.shtml

I'm running IDA Pro 7.5.200619 with Python 2.7.18.

The only testing I've done is run the script in IDA Pro and I could see the subview having strings clustered by function and I could jump to those functions with a double-click.